### PR TITLE
feat: Add list nodes tests

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -39,7 +39,7 @@ export const getNodes = async (fetchNodes = fetchNodesFromViewblock) => {
 
 /**
  * Fetches arweave nodes from the ViewBlock API
- * 
+ *
  * @param {number} page
  */
 const fetchNodesFromViewblock = (page) => {

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1,0 +1,54 @@
+const IP_ADDRESS_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/
+
+export const getNodes = async (fetchNodes = fetchNodesFromViewblock) => {
+  // TODO: Find a publicly documented API
+  const docs = []
+  let maxPage = Infinity
+  for (let page = 0; page < maxPage; page++) {
+    const res = await fetchNodes(page)
+    const body = await res.json()
+    if (maxPage === Infinity) {
+      maxPage = body.pages
+    }
+    docs.push(...body.docs)
+  }
+  const nodes = [
+    {
+      host: 'arweave.net',
+      port: 443,
+      protocol: 'https'
+    },
+    ...docs
+      .map(doc => doc.id)
+      .filter(Boolean)
+      .map(addr => {
+        const [host, port] = addr.split(':')
+        const protocol = IP_ADDRESS_REGEX.test(host) ? 'http' : 'https'
+        return {
+          host,
+          port: port
+            ? Number(port)
+            : protocol === 'http' ? 80 : 443,
+          protocol
+        }
+      })
+  ]
+  console.log(`Found ${nodes.length} nodes`)
+  return nodes
+}
+
+/**
+ * Fetches arweave nodes from the ViewBlock API
+ * 
+ * @param {number} page
+ */
+const fetchNodesFromViewblock = (page) => {
+  return fetch(
+    `https://api.viewblock.io/arweave/nodes?page=${page}&network=mainnet`,
+    {
+      headers: {
+        Origin: 'https://viewblock.io'
+      }
+    }
+  )
+}

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@
 
 import './vendor/arweave.js'
 import pTimeout from './vendor/p-timeout.js'
+import { getNodes } from './lib/nodes.js'
 
 const IP_ADDRESS_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/
 const ONE_MINUTE = 60_000
@@ -15,50 +16,6 @@ const RANDOM_TRANSACTION_IDS = [
   's2aJ5tzVEcSxITsq2G5cZnAhBDplCSkARJEOuNMZ31o'
 ]
 const RETRIEVE_TIMEOUT = 10_000
-
-const getNodes = async () => {
-  // TODO: Find a publicly documented API
-  const docs = []
-  let maxPage = Infinity
-  for (let page = 0; page < maxPage; page++) {
-    const res = await fetch(
-      `https://api.viewblock.io/arweave/nodes?page=${page + 1}&network=mainnet`,
-      {
-        headers: {
-          Origin: 'https://viewblock.io'
-        }
-      }
-    )
-    const body = await res.json()
-    if (maxPage === Infinity) {
-      maxPage = body.pages
-    }
-    docs.push(...body.docs)
-  }
-  const nodes = [
-    {
-      host: 'arweave.net',
-      port: 443,
-      protocol: 'https'
-    },
-    ...docs
-      .map(doc => doc.id)
-      .filter(Boolean)
-      .map(addr => {
-        const [host, port] = addr.split(':')
-        const protocol = IP_ADDRESS_REGEX.test(host) ? 'http' : 'https'
-        return {
-          host,
-          port: port
-            ? Number(port)
-            : protocol === 'http' ? 80 : 443,
-          protocol
-        }
-      })
-  ]
-  console.log(`Found ${nodes.length} nodes`)
-  return nodes
-}
 
 const measure = async node => {
   const arweave = Arweave.init(node)

--- a/main.js
+++ b/main.js
@@ -4,7 +4,6 @@ import './vendor/arweave.js'
 import pTimeout from './vendor/p-timeout.js'
 import { getNodes } from './lib/nodes.js'
 
-const IP_ADDRESS_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/
 const ONE_MINUTE = 60_000
 const MEASUREMENT_DELAY = ONE_MINUTE
 const UPDATE_NODES_DELAY = 10 * ONE_MINUTE

--- a/test.js
+++ b/test.js
@@ -1,1 +1,1 @@
-import './tests/example.test.js'
+import './tests/nodes.test.js'

--- a/tests/example.test.js
+++ b/tests/example.test.js
@@ -1,6 +1,0 @@
-import { test } from 'zinnia:test'
-import { assertEquals } from 'zinnia:assert'
-
-test('example test', () => {
-  assertEquals(1 + 1, 2)
-})

--- a/tests/nodes.test.js
+++ b/tests/nodes.test.js
@@ -12,10 +12,9 @@ test('should arweave node by default', async () => {
     })
   }
 
-  const nodes = await getNodes(mockFetch);
-  console.log(nodes)
+  const nodes = await getNodes(mockFetch)
   assertEquals(nodes, [{
-    host: "arweave.net", port: 443, protocol: "https"
+    host: 'arweave.net', port: 443, protocol: 'https'
   }])
 })
 
@@ -38,21 +37,21 @@ test('should return nodes from all pages with a custom fetch function', async ()
       json: () => ({
         pages: 2,
         docs: [
-            { id: '127.0.0.1' },
-            { id: 'test.arweave.net' },
-            { id: '' },
+          { id: '127.0.0.1' },
+          { id: 'test.arweave.net' },
+          { id: '' }
         ]
       })
     })
   }
 
-  const nodes = await getNodes(mockFetch);
+  const nodes = await getNodes(mockFetch)
   assertEquals(nodes.length, 5)
   assertEquals(nodes, [
     { host: 'arweave.net', port: 443, protocol: 'https' },
     { host: '127.0.0.1', port: 1984, protocol: 'http' },
     { host: '127.0.0.1', port: 1986, protocol: 'http' },
     { host: '127.0.0.1', port: 80, protocol: 'http' },
-    { host: 'test.arweave.net', port: 443, protocol: 'https' },
+    { host: 'test.arweave.net', port: 443, protocol: 'https' }
   ])
 })

--- a/tests/nodes.test.js
+++ b/tests/nodes.test.js
@@ -19,35 +19,6 @@ test('should arweave node by default', async () => {
   }])
 })
 
-test('should return nodes with a custom fetch function', async () => {
-  const mockFetch = (pages) => {
-    return Promise.resolve({
-      json: () => ({
-        pages: 1,
-        docs: [
-          { id: '127.0.0.1:1984' },
-          { id: '127.0.0.1:1986' },
-          { id: '127.0.0.1' },
-          { id: 'test.arweave.net' },
-          { id: '' },
-          {}
-        ]
-      })
-    })
-  }
-
-  const nodes = await getNodes(mockFetch);
-  assertEquals(nodes.length, 5)
-  assertEquals(nodes, [
-    { host: 'arweave.net', port: 443, protocol: 'https' },
-    { host: '127.0.0.1', port: 1984, protocol: 'http' },
-    { host: '127.0.0.1', port: 1986, protocol: 'http' },
-    { host: '127.0.0.1', port: 80, protocol: 'http' },
-    { host: 'test.arweave.net', port: 443, protocol: 'https' },
-  ])
-})
-
-
 test('should return nodes from all pages with a custom fetch function', async () => {
   const mockFetch = (page) => {
     if (page === 0) {

--- a/tests/nodes.test.js
+++ b/tests/nodes.test.js
@@ -1,0 +1,87 @@
+import { test } from 'zinnia:test'
+import { assertEquals } from 'zinnia:assert'
+import { getNodes } from '../lib/nodes.js'
+
+test('should arweave node by default', async () => {
+  const mockFetch = (pages) => {
+    return Promise.resolve({
+      json: () => ({
+        pages: 1,
+        docs: []
+      })
+    })
+  }
+
+  const nodes = await getNodes(mockFetch);
+  console.log(nodes)
+  assertEquals(nodes, [{
+    host: "arweave.net", port: 443, protocol: "https"
+  }])
+})
+
+test('should return nodes with a custom fetch function', async () => {
+  const mockFetch = (pages) => {
+    return Promise.resolve({
+      json: () => ({
+        pages: 1,
+        docs: [
+          { id: '127.0.0.1:1984' },
+          { id: '127.0.0.1:1986' },
+          { id: '127.0.0.1' },
+          { id: 'test.arweave.net' },
+          { id: '' },
+          {}
+        ]
+      })
+    })
+  }
+
+  const nodes = await getNodes(mockFetch);
+  assertEquals(nodes.length, 5)
+  assertEquals(nodes, [
+    { host: 'arweave.net', port: 443, protocol: 'https' },
+    { host: '127.0.0.1', port: 1984, protocol: 'http' },
+    { host: '127.0.0.1', port: 1986, protocol: 'http' },
+    { host: '127.0.0.1', port: 80, protocol: 'http' },
+    { host: 'test.arweave.net', port: 443, protocol: 'https' },
+  ])
+})
+
+
+test('should return nodes from all pages with a custom fetch function', async () => {
+  const mockFetch = (page) => {
+    if (page === 0) {
+      return Promise.resolve({
+        json: () => ({
+          pages: 2,
+          docs: [
+            { id: '127.0.0.1:1984' },
+            { id: '127.0.0.1:1986' },
+            {}
+          ]
+        })
+      })
+    }
+
+    return Promise.resolve({
+      json: () => ({
+        pages: 2,
+        docs: [
+            { id: '127.0.0.1' },
+            { id: 'test.arweave.net' },
+            { id: '' },
+        ]
+      })
+    })
+  }
+
+  const nodes = await getNodes(mockFetch);
+  assertEquals(nodes.length, 5)
+  assertEquals(nodes, [
+    { host: 'arweave.net', port: 443, protocol: 'https' },
+    { host: '127.0.0.1', port: 1984, protocol: 'http' },
+    { host: '127.0.0.1', port: 1986, protocol: 'http' },
+    { host: '127.0.0.1', port: 80, protocol: 'http' },
+    { host: 'test.arweave.net', port: 443, protocol: 'https' },
+  ])
+})

--- a/tests/nodes.test.js
+++ b/tests/nodes.test.js
@@ -2,7 +2,7 @@ import { test } from 'zinnia:test'
 import { assertEquals } from 'zinnia:assert'
 import { getNodes } from '../lib/nodes.js'
 
-test('should arweave node by default', async () => {
+test('should return arweave.net node by default', async () => {
   const mockFetch = (pages) => {
     return Promise.resolve({
       json: () => ({


### PR DESCRIPTION
Extracts the logic for listing Arweave nodes into a separate library and adds corresponding tests.

Closes #10 